### PR TITLE
Update to Zig master

### DIFF
--- a/src/qoi.zig
+++ b/src/qoi.zig
@@ -1,5 +1,3 @@
-// updated for zig version 0.12.0
-
 const std = @import("std");
 const logger = std.log.scoped(.qoi);
 


### PR DESCRIPTION
Zig 0.12.0 requires using `const` instead of `var` and using `@memcpy` instead of `std.mem.copy`.